### PR TITLE
Add brand color theme

### DIFF
--- a/src/app/dictionary/page.tsx
+++ b/src/app/dictionary/page.tsx
@@ -9,7 +9,7 @@ import DictionarySearch from '@/components/DictionarySearch';
 
 export default function HomePage() {
   return (
-    <main className="min-h-screen bg-black text-white p-6 space-y-12">
+    <main className="min-h-screen p-6 space-y-12">
       <header className="flex justify-between items-center mb-6">
         <h1 className="text-3xl font-bold">JugsDrive DApp</h1>
         <ConnectButton />

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,5 +4,6 @@
 
 /* Optional custom global styles */
 body {
-  @apply bg-black text-white font-sans;
+  /* Use brand colors so the app isn't limited to black and white */
+  @apply bg-brand-light text-brand-dark font-sans;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,7 +13,8 @@ const queryClient = new QueryClient();
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <body className="bg-black text-white font-sans">
+      {/* Global styles define the background and text colors */}
+      <body className="font-sans">
         <WagmiProvider config={wagmiConfig}>
           <QueryClientProvider client={queryClient}>
             <RainbowKitProvider theme={darkTheme()} modalSize="compact">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,7 +11,7 @@ import BuyJugsBox from '@/components/BuyJugsBox';
 
 export default function HomePage() {
   return (
-    <main className="min-h-screen bg-black text-white p-6 space-y-12">
+    <main className="min-h-screen p-6 space-y-12">
       <header className="flex justify-between items-center mb-6">
         <h1 className="text-3xl font-bold">JugsDrive DApp</h1>
         <CustomConnect />

--- a/src/components/BuyJugsBox.tsx
+++ b/src/components/BuyJugsBox.tsx
@@ -2,7 +2,7 @@
 
 export default function BuyJugsBox() {
   return (
-    <div className="bg-zinc-800 p-4 rounded text-white">
+    <div className="bg-brand-dark p-4 rounded text-brand-light">
       <h3 className="text-yellow-400 mb-1">Buy JUGS</h3>
       <div className="text-lg">
         {/* Add actual DEX pair link later */}

--- a/src/components/ClaimableJugsBox.tsx
+++ b/src/components/ClaimableJugsBox.tsx
@@ -6,7 +6,7 @@ export default function ClaimableJugsBox() {
   const { address } = useAccount();
 
   return (
-    <div className="bg-zinc-800 p-4 rounded text-white">
+    <div className="bg-brand-dark p-4 rounded text-brand-light">
       <h3 className="text-yellow-400 mb-1">Claimable JUGS</h3>
       <div className="text-lg">
         {/* Replace with backend/graph data about claimable JUGS */}

--- a/src/components/DictionarySearch.tsx
+++ b/src/components/DictionarySearch.tsx
@@ -28,7 +28,7 @@ export default function DictionarySearch() {
       <input
         type="text"
         placeholder="Search terms like NFT, DAO, wallet..."
-        className="w-full p-2 mb-4 rounded bg-black text-white border border-zinc-700 focus:outline-none focus:ring focus:ring-yellow-400"
+        className="w-full p-2 mb-4 rounded bg-brand-light text-brand-dark border border-brand-dark focus:outline-none focus:ring focus:ring-brand"
         value={searchTerm}
         onChange={(e) => setSearchTerm(e.target.value)}
       />

--- a/src/components/DrumDepositsBox.tsx
+++ b/src/components/DrumDepositsBox.tsx
@@ -6,7 +6,7 @@ export default function DrumDepositsBox() {
   const { address } = useAccount();
 
   return (
-    <div className="bg-zinc-800 p-4 rounded text-white">
+    <div className="bg-brand-dark p-4 rounded text-brand-light">
       <h3 className="text-yellow-400 mb-1">Drum Deposits</h3>
       <div className="text-lg">
         {address ? 'Tracking deposit tiers (placeholder)' : 'Connect wallet to view'}

--- a/src/components/JugsBalanceBox.tsx
+++ b/src/components/JugsBalanceBox.tsx
@@ -6,7 +6,7 @@ export default function JugsBalanceBox() {
   const { address } = useAccount();
 
   return (
-    <div className="bg-zinc-800 p-4 rounded text-white">
+    <div className="bg-brand-dark p-4 rounded text-brand-light">
       <h3 className="text-yellow-400 mb-1">Your JUGS Balance</h3>
       <div className="text-lg">
         {/* Replace with actual token balance logic */}


### PR DESCRIPTION
## Summary
- switch global styles to use brand colors
- apply brand palette to layout and main pages
- brighten dictionary search UI
- change info boxes to brand dark colors

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854af3ea53c8329a408ad887bc95c9b